### PR TITLE
Fix badge time display logic

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -291,7 +291,7 @@ function updateBadge() {
                         const minutes = Math.floor((remaining % 3600) / 60);
                         badgeText = `${hours.toString().padStart(2, "0")}:${minutes.toString().padStart(2, "0")}`;
                     }
-                    else if (remaining < 3600) {
+                    else if (remaining >= 60) {
                         const minutes = Math.floor(remaining / 60);
                         const seconds = remaining % 60;
                         badgeText = `${minutes.toString().padStart(2, "0")}:${seconds.toString().padStart(2, "0")}`;

--- a/tests/badge.test.js
+++ b/tests/badge.test.js
@@ -38,6 +38,25 @@ describe('Badge Update Logic', () => {
         done();
     });
 
+    test('displays seconds on the badge when less than a minute remains', (done) => {
+        const timer = {
+            timerId: "test_timer_sec",
+            tabId: 1,
+            tabTitle: "Active Tab",
+            originalDuration: 45,
+            startTime: fixedTime,
+            targetTime: fixedTime + 45 * 1000,
+            paused: false
+        };
+
+        global.chrome.storage.local.get = jest.fn((key, cb) => {
+            cb({ "timer_test_timer_sec": timer });
+        });
+        updateBadge();
+        expect(global.chrome.action.setBadgeText).toHaveBeenCalledWith({ text: "45s", tabId: 1 });
+        done();
+    });
+
     test('clears the badge when no active timer is found for the active tab', (done) => {
         global.chrome.storage.local.get = jest.fn((key, cb) => {
             cb({});


### PR DESCRIPTION
## Summary
- fix time display logic in updateBadge to handle seconds
- test seconds badge behavior when remaining time < 60 seconds

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687721b69ffc83229d98eaafc086c4ce