### PR TITLE
Add popup theme manager that syncs with browser theme

### DIFF
--- a/documentation/changes/v0.1.0.md
+++ b/documentation/changes/v0.1.0.md
@@ -1,0 +1,9 @@
+# v0.1.0 - Popup Theme Synchronization
+
+## Summary
+- add a theme manager for the popup that applies cached palettes immediately on load
+- derive a contrast-safe popup palette from the active browser theme and persist it for reuse
+- subscribe to browser theme updates so the popup refreshes its palette without reloading
+
+## Testing
+- npm test

--- a/src/popup.js
+++ b/src/popup.js
@@ -1,4 +1,295 @@
+const POPUP_THEME_STORAGE_KEY = "popupThemeVariables";
+
+const POPUP_CSS_VARIABLES = {
+    frame: "--popup-bg",
+    toolbar: "--popup-surface",
+    tab_text: "--text-color",
+    toolbar_button_icon: "--button-icon"
+};
+
+function createThemeManager() {
+    const root = document.documentElement;
+    let listenerRegistered = false;
+
+    const readCachedVariables = () => new Promise((resolve) => {
+        try {
+            chrome.storage.local.get(POPUP_THEME_STORAGE_KEY, (data) => {
+                resolve(data?.[POPUP_THEME_STORAGE_KEY] || null);
+            });
+        } catch (error) {
+            console.warn("Failed to read cached popup theme", error);
+            resolve(null);
+        }
+    });
+
+    const persistVariables = (variables) => new Promise((resolve) => {
+        try {
+            chrome.storage.local.set({ [POPUP_THEME_STORAGE_KEY]: variables }, () => resolve());
+        } catch (error) {
+            console.warn("Failed to persist popup theme", error);
+            resolve();
+        }
+    });
+
+    const applyVariables = (variables) => {
+        if (!variables) return;
+        Object.entries(variables).forEach(([cssVar, value]) => {
+            if (value) {
+                root.style.setProperty(cssVar, value);
+            }
+        });
+    };
+
+    const normalizeColor = (color) => {
+        if (!color && color !== 0) return null;
+        if (Array.isArray(color)) {
+            const [r = 0, g = 0, b = 0, a = 255] = color;
+            return rgbToCss({ r, g, b, a: clampAlpha(a / 255) });
+        }
+        if (typeof color === "string") {
+            return color;
+        }
+        return null;
+    };
+
+    const fetchTheme = () => new Promise((resolve) => {
+        if (chrome.theme?.getCurrent) {
+            try {
+                chrome.theme.getCurrent((theme) => {
+                    if (theme && Object.keys(theme).length) {
+                        resolve(theme);
+                        return;
+                    }
+                    resolve(null);
+                });
+                return;
+            } catch (error) {
+                console.warn("chrome.theme.getCurrent failed", error);
+            }
+        }
+        if (chrome.management?.getAll) {
+            try {
+                chrome.management.getAll((items) => {
+                    const themeInfo = items?.find((item) => item.type === "theme" && item.enabled && item.theme);
+                    resolve(themeInfo?.theme || null);
+                });
+                return;
+            } catch (error) {
+                console.warn("chrome.management.getAll failed", error);
+            }
+        }
+        resolve(null);
+    });
+
+    const deriveVariables = (theme) => {
+        const defaults = getDefaultPalette();
+        const colors = theme?.colors || theme || {};
+
+        const baseColors = Object.fromEntries(
+            Object.entries(POPUP_CSS_VARIABLES).map(([themeKey]) => [
+                themeKey,
+                normalizeColor(colors?.[themeKey]) || defaults[themeKey]
+            ])
+        );
+
+        const background = baseColors.frame || defaults.frame;
+        const surface = baseColors.toolbar || shadeColor(background, 0.06);
+        const textColor = ensureReadableColor(background, baseColors.tab_text || defaults.tab_text);
+        const buttonIconColor = ensureReadableColor(surface, baseColors.toolbar_button_icon || textColor);
+        const buttonBackground = shadeColor(surface, -0.18);
+        const borderColor = shadeColor(surface, -0.25);
+
+        return {
+            [POPUP_CSS_VARIABLES.frame]: background,
+            [POPUP_CSS_VARIABLES.toolbar]: surface,
+            [POPUP_CSS_VARIABLES.tab_text]: textColor,
+            [POPUP_CSS_VARIABLES.toolbar_button_icon]: buttonIconColor,
+            "--button-bg": buttonBackground,
+            "--button-text": ensureReadableColor(buttonBackground, textColor),
+            "--border-color": borderColor
+        };
+    };
+
+    const refreshTheme = async (explicitTheme = null) => {
+        const themeData = explicitTheme || await fetchTheme();
+        const variables = deriveVariables(themeData);
+        applyVariables(variables);
+        await persistVariables(variables);
+    };
+
+    const handleThemeUpdate = (updateInfo) => {
+        const updatedTheme = updateInfo?.theme || null;
+        refreshTheme(updatedTheme).catch((error) => {
+            console.error("Failed to refresh popup theme", error);
+        });
+    };
+
+    const registerListener = () => {
+        if (listenerRegistered) return;
+        if (chrome.theme?.onUpdated?.addListener) {
+            chrome.theme.onUpdated.addListener(handleThemeUpdate);
+            listenerRegistered = true;
+        }
+    };
+
+    const init = async () => {
+        try {
+            const cached = await readCachedVariables();
+            if (cached) {
+                applyVariables(cached);
+            }
+            await refreshTheme();
+        } catch (error) {
+            console.error("Failed to initialise popup theme", error);
+        } finally {
+            registerListener();
+        }
+    };
+
+    return { init };
+}
+
+const clampAlpha = (value) => {
+    if (Number.isNaN(value)) return 1;
+    return Math.min(1, Math.max(0, value));
+};
+
+const rgbToCss = ({ r, g, b, a = 1 }) => {
+    if (a < 1) {
+        return `rgba(${Math.round(r)}, ${Math.round(g)}, ${Math.round(b)}, ${Number(a.toFixed(3))})`;
+    }
+    return rgbToHex(Math.round(r), Math.round(g), Math.round(b));
+};
+
+const rgbToHex = (r, g, b) => {
+    const componentToHex = (c) => {
+        const hex = c.toString(16);
+        return hex.length === 1 ? `0${hex}` : hex;
+    };
+    return `#${componentToHex(r)}${componentToHex(g)}${componentToHex(b)}`;
+};
+
+const parseColorToRgb = (color) => {
+    if (!color) return null;
+    if (Array.isArray(color)) {
+        const [r = 0, g = 0, b = 0, a = 1] = color;
+        return { r, g, b, a: clampAlpha(a) };
+    }
+    if (typeof color === "string") {
+        const hexMatch = color.trim().match(/^#([0-9a-f]{3}|[0-9a-f]{6})$/i);
+        if (hexMatch) {
+            let hex = hexMatch[1];
+            if (hex.length === 3) {
+                hex = hex.split("").map((char) => `${char}${char}`).join("");
+            }
+            const intVal = parseInt(hex, 16);
+            return {
+                r: (intVal >> 16) & 255,
+                g: (intVal >> 8) & 255,
+                b: intVal & 255,
+                a: 1
+            };
+        }
+        const rgbaMatch = color.trim().match(/^rgba?\(([^)]+)\)$/i);
+        if (rgbaMatch) {
+            const parts = rgbaMatch[1].split(/\s*,\s*/).map(Number);
+            const [r = 0, g = 0, b = 0, a = 1] = parts;
+            return { r, g, b, a: clampAlpha(a) };
+        }
+    }
+    return null;
+};
+
+const luminance = ({ r, g, b }) => {
+    const transform = (c) => {
+        const channel = c / 255;
+        return channel <= 0.03928 ? channel / 12.92 : Math.pow((channel + 0.055) / 1.055, 2.4);
+    };
+    return 0.2126 * transform(r) + 0.7152 * transform(g) + 0.0722 * transform(b);
+};
+
+const contrastRatio = (colorA, colorB) => {
+    const lumA = luminance(colorA);
+    const lumB = luminance(colorB);
+    const brightest = Math.max(lumA, lumB);
+    const darkest = Math.min(lumA, lumB);
+    return (brightest + 0.05) / (darkest + 0.05);
+};
+
+const getReadableTextColor = (background) => {
+    const bg = parseColorToRgb(background);
+    if (!bg) return "#000000";
+    return luminance(bg) > 0.4 ? "#1a1a1a" : "#f5f5f5";
+};
+
+const ensureReadableColor = (background, candidate, fallbackBackground = null, preferInverse = false) => {
+    const bg = parseColorToRgb(background);
+    if (!bg) {
+        return candidate || getReadableTextColor(fallbackBackground || background);
+    }
+    if (!candidate) {
+        return getReadableTextColor(background);
+    }
+    const candidateRgb = parseColorToRgb(candidate);
+    if (!candidateRgb) {
+        return candidate;
+    }
+    if (contrastRatio(bg, candidateRgb) < 4.5) {
+        if (preferInverse) {
+            const inverted = rgbToCss({
+                r: 255 - candidateRgb.r,
+                g: 255 - candidateRgb.g,
+                b: 255 - candidateRgb.b,
+                a: candidateRgb.a
+            });
+            const invertedRgb = parseColorToRgb(inverted);
+            if (invertedRgb && contrastRatio(bg, invertedRgb) >= 4.5) {
+                return inverted;
+            }
+        }
+        return getReadableTextColor(background);
+    }
+    return rgbToCss(candidateRgb);
+};
+
+const shadeColor = (color, percent) => {
+    const rgb = parseColorToRgb(color);
+    if (!rgb) return color;
+    const t = percent < 0 ? 0 : 255;
+    const p = Math.abs(percent);
+    const r = Math.round((t - rgb.r) * p + rgb.r);
+    const g = Math.round((t - rgb.g) * p + rgb.g);
+    const b = Math.round((t - rgb.b) * p + rgb.b);
+    return rgbToCss({ r, g, b, a: rgb.a });
+};
+
+const getDefaultPalette = () => {
+    const mediaQuery = typeof window !== "undefined" && typeof window.matchMedia === "function"
+        ? window.matchMedia("(prefers-color-scheme: dark)")
+        : null;
+    const prefersDark = mediaQuery ? mediaQuery.matches : false;
+    if (prefersDark) {
+        return {
+            frame: "#202124",
+            toolbar: "#2d2f33",
+            tab_text: "#e8eaed",
+            toolbar_button_icon: "#f1f3f4"
+        };
+    }
+    return {
+        frame: "#ffffff",
+        toolbar: "#f1f3f4",
+        tab_text: "#202124",
+        toolbar_button_icon: "#3c4043"
+    };
+};
+
+const themeManager = createThemeManager();
+
 document.addEventListener("DOMContentLoaded", () => {
+    themeManager.init().catch((error) => {
+        console.error("Theme manager failed to initialise", error);
+    });
     // Tab switching logic:
     const tabTimer = document.getElementById("tabTimer");
     const tabSettings = document.getElementById("tabSettings");


### PR DESCRIPTION
## Summary
- add a popup theme manager that rehydrates cached palettes, derives variables from the active browser theme, and persists them
- provide helper utilities to normalize theme colors, ensure readable contrast, and listen for theme updates
- document the popup theming changes in the change log directory

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68fd90697a98832286766cb080e2a26e