### PR TITLE
Add theme permission and cover popup theme manager

### DIFF
--- a/documentation/changes/v0.1.2.md
+++ b/documentation/changes/v0.1.2.md
@@ -1,0 +1,10 @@
+# v0.1.2 - Theme Permission Enablement
+
+## Summary
+- add the chrome.theme permission to the extension manifest so the popup can read browser theme data
+- extend chrome API mocks with theme and management stubs to support theme-aware behaviours in tests
+- cover the popup theme manager with a new test that ensures it calls chrome.theme.getCurrent when the APIs are available
+
+## Testing
+- npm test
+- npm run build

--- a/mocks/chrome.js
+++ b/mocks/chrome.js
@@ -29,6 +29,21 @@ function createNotificationsMock() {
     };
 }
 
+function createThemeMock() {
+    return {
+        getCurrent: jest.fn((callback) => callback && callback(null)),
+        onUpdated: {
+            addListener: jest.fn()
+        }
+    };
+}
+
+function createManagementMock() {
+    return {
+        getAll: jest.fn((callback) => callback && callback([]))
+    };
+}
+
 function createTabsMock() {
     return {
         query: jest.fn((queryInfo, callback) => {
@@ -67,6 +82,8 @@ function createChromeMock() {
         },
         alarms: createAlarmsMock(),
         notifications: createNotificationsMock(),
+        theme: createThemeMock(),
+        management: createManagementMock(),
         tabs: createTabsMock(),
         runtime: createRuntimeMock()
     };

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -8,7 +8,8 @@
     "tabs",
     "storage",
     "notifications",
-    "alarms"
+    "alarms",
+    "theme"
   ],
   "background": {
     "service_worker": "background.js"

--- a/tests/popupTheme.test.js
+++ b/tests/popupTheme.test.js
@@ -1,0 +1,46 @@
+const { createChromeMock } = require('../mocks/chrome');
+
+describe('Popup theme manager', () => {
+    beforeEach(() => {
+        jest.resetModules();
+        global.chrome = createChromeMock();
+
+        const popupHtml = `
+            <div class="container">
+                <button id="tabTimer"></button>
+                <button id="tabSettings"></button>
+                <div id="timerSection"></div>
+                <div id="settingsSection"></div>
+                <input id="notificationsToggle" type="checkbox" />
+                <input id="hoursInput" />
+                <input id="minutesInput" />
+                <input id="secondsInput" />
+                <button id="startTimerBtn"></button>
+                <div id="timersList"></div>
+            </div>
+        `;
+        document.body.innerHTML = popupHtml;
+
+        const themeResponse = {
+            colors: {
+                frame: '#101010',
+                toolbar: '#202020',
+                tab_text: '#f0f0f0',
+                toolbar_button_icon: '#fafafa'
+            }
+        };
+        chrome.theme.getCurrent.mockImplementation((callback) => callback(themeResponse));
+        document.documentElement.style.setProperty = jest.fn();
+    });
+
+    test('initialises using chrome.theme APIs when available', async () => {
+        require('../src/popup.js');
+        document.dispatchEvent(new Event('DOMContentLoaded'));
+
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(chrome.theme.getCurrent).toHaveBeenCalled();
+        expect(chrome.theme.onUpdated.addListener).toHaveBeenCalledWith(expect.any(Function));
+        expect(document.documentElement.style.setProperty).toHaveBeenCalledWith('--popup-bg', '#101010');
+    });
+});


### PR DESCRIPTION
## Summary
- grant the extension the chrome.theme permission required for popup theme APIs
- extend chrome mocks with theme and management stubs so tests can exercise theme flows
- add a popup theme manager test ensuring the theme APIs are invoked during initialisation

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fd92808cd48322a48606cecf9f1200