### PR TITLE
Align popup theme variables with active theme

### DIFF
--- a/documentation/changes/v0.1.3.md
+++ b/documentation/changes/v0.1.3.md
@@ -1,0 +1,9 @@
+# v0.1.3 - Popup Theme Variable Refresh
+
+## Summary
+- align the popup theme variable derivation with the CSS variables actually used by the UI for consistent theming
+- compute button, status, and shadow colors from the active browser theme so all popup elements react immediately to theme updates
+- expand the popup theme test coverage to ensure the refreshed variable set is applied and legacy keys are no longer emitted
+
+## Testing
+- npm test

--- a/src/popup.js
+++ b/src/popup.js
@@ -1,10 +1,10 @@
 const POPUP_THEME_STORAGE_KEY = "popupThemeVariables";
 
 const POPUP_CSS_VARIABLES = {
-    frame: "--popup-bg",
-    toolbar: "--popup-surface",
+    frame: "--body-bg-color",
+    toolbar: "--container-bg-color",
     tab_text: "--text-color",
-    toolbar_button_icon: "--button-icon"
+    toolbar_button_icon: "--accent-color"
 };
 
 function createThemeManager() {
@@ -94,19 +94,62 @@ function createThemeManager() {
 
         const background = baseColors.frame || defaults.frame;
         const surface = baseColors.toolbar || shadeColor(background, 0.06);
-        const textColor = ensureReadableColor(background, baseColors.tab_text || defaults.tab_text);
-        const buttonIconColor = ensureReadableColor(surface, baseColors.toolbar_button_icon || textColor);
-        const buttonBackground = shadeColor(surface, -0.18);
-        const borderColor = shadeColor(surface, -0.25);
+        const surfaceRgb = parseColorToRgb(surface);
+        const surfaceIsLight = surfaceRgb ? luminance(surfaceRgb) >= 0.5 : true;
+
+        const textCandidate = baseColors.tab_text || defaults.tab_text;
+        const textColor = ensureReadableColor(surface, textCandidate, background);
+        const tabTextColor = ensureReadableColor(surface, textCandidate, background);
+
+        const accentCandidate = baseColors.toolbar_button_icon || textColor;
+        const accentColor = ensureReadableColor(surface, accentCandidate, background, true);
+        const accent = accentColor || textColor;
+
+        const buttonBackground = surfaceIsLight ? shadeColor(accent, -0.3) : shadeColor(accent, 0.3);
+        const buttonTextColor = ensureReadableColor(buttonBackground, textColor, surface, true);
+        const buttonHover = surfaceIsLight ? shadeColor(buttonBackground, -0.12) : shadeColor(buttonBackground, 0.12);
+
+        const borderColor = surfaceIsLight ? shadeColor(surface, -0.25) : shadeColor(surface, 0.25);
+        const inputBackground = surfaceIsLight ? shadeColor(surface, 0.04) : shadeColor(surface, 0.18);
+
+        const containerShadowColor = surfaceIsLight ? "rgba(0, 0, 0, 0.18)" : "rgba(0, 0, 0, 0.6)";
+        const cardShadowColor = surfaceIsLight ? "rgba(0, 0, 0, 0.14)" : "rgba(0, 0, 0, 0.5)";
+
+        const statusActiveColor = accent;
+        const statusIconActiveBg = surfaceIsLight ? shadeColor(accent, -0.18) : shadeColor(accent, 0.18);
+        const statusIconTextColor = ensureReadableColor(statusIconActiveBg, buttonTextColor, surface, true);
+        const statusIconPausedBg = surfaceIsLight ? shadeColor(borderColor, -0.08) : shadeColor(borderColor, 0.12);
+
+        const progressBarBg = accent;
+        const timerTextColor = ensureReadableColor(surface, textColor, background);
+
+        const tabIconFilter = surfaceIsLight ? "none" : "brightness(0) invert(1)";
+        const iconGlow = withAlpha(accent, surfaceIsLight ? 0.5 : 0.7);
+        const tabIconHighlightFilter = tabIconFilter === "none"
+            ? `drop-shadow(0 0 2px ${iconGlow})`
+            : `${tabIconFilter} drop-shadow(0 0 2px ${iconGlow})`;
 
         return {
-            [POPUP_CSS_VARIABLES.frame]: background,
-            [POPUP_CSS_VARIABLES.toolbar]: surface,
-            [POPUP_CSS_VARIABLES.tab_text]: textColor,
-            [POPUP_CSS_VARIABLES.toolbar_button_icon]: buttonIconColor,
+            "--body-bg-color": background,
+            "--container-bg-color": surface,
+            "--text-color": textColor,
+            "--tab-text-color": tabTextColor,
             "--button-bg": buttonBackground,
-            "--button-text": ensureReadableColor(buttonBackground, textColor),
-            "--border-color": borderColor
+            "--button-bg-hover": buttonHover,
+            "--button-text-color": buttonTextColor,
+            "--border-color": borderColor,
+            "--input-bg": inputBackground,
+            "--timer-text-color": timerTextColor,
+            "--container-shadow-color": containerShadowColor,
+            "--card-shadow-color": cardShadowColor,
+            "--tab-icon-filter": tabIconFilter,
+            "--tab-icon-highlight-filter": tabIconHighlightFilter,
+            "--status-active-color": statusActiveColor,
+            "--status-icon-active-bg": statusIconActiveBg,
+            "--status-icon-text-color": statusIconTextColor,
+            "--status-icon-paused-bg": statusIconPausedBg,
+            "--progress-bar-bg": progressBarBg,
+            "--corner-radius": "8px"
         };
     };
 
@@ -261,6 +304,14 @@ const shadeColor = (color, percent) => {
     const g = Math.round((t - rgb.g) * p + rgb.g);
     const b = Math.round((t - rgb.b) * p + rgb.b);
     return rgbToCss({ r, g, b, a: rgb.a });
+};
+
+const withAlpha = (color, alpha) => {
+    const rgb = parseColorToRgb(color);
+    if (!rgb) {
+        return `rgba(0, 0, 0, ${alpha})`;
+    }
+    return `rgba(${Math.round(rgb.r)}, ${Math.round(rgb.g)}, ${Math.round(rgb.b)}, ${clampAlpha(alpha)})`;
 };
 
 const getDefaultPalette = () => {

--- a/tests/popupTheme.test.js
+++ b/tests/popupTheme.test.js
@@ -39,8 +39,22 @@ describe('Popup theme manager', () => {
 
         await new Promise((resolve) => setTimeout(resolve, 0));
 
+        const setProperty = document.documentElement.style.setProperty;
+
         expect(chrome.theme.getCurrent).toHaveBeenCalled();
         expect(chrome.theme.onUpdated.addListener).toHaveBeenCalledWith(expect.any(Function));
-        expect(document.documentElement.style.setProperty).toHaveBeenCalledWith('--popup-bg', '#101010');
+        expect(setProperty).toHaveBeenCalledWith('--body-bg-color', '#101010');
+
+        const appliedVariables = new Map(setProperty.mock.calls.map(([key, value]) => [key, value]));
+
+        expect(appliedVariables.get('--container-bg-color')).toBe('#202020');
+        expect(appliedVariables.has('--button-bg')).toBe(true);
+        expect(appliedVariables.has('--button-bg-hover')).toBe(true);
+        expect(appliedVariables.has('--button-text-color')).toBe(true);
+        expect(appliedVariables.has('--container-shadow-color')).toBe(true);
+        expect(appliedVariables.has('--status-active-color')).toBe(true);
+        expect(appliedVariables.has('--tab-icon-filter')).toBe(true);
+        expect(appliedVariables.has('--popup-bg')).toBe(false);
+        expect(appliedVariables.has('--button-text')).toBe(false);
     });
 });


### PR DESCRIPTION
## Summary
- align the popup theme CSS variables with the values consumed by the popup and drop legacy keys
- derive hover, status, and shadow colors from the current browser theme so all elements restyle together
- extend popup theme coverage and document the change in the changelog

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68fd949401c08322b2689c212306d256